### PR TITLE
Figure 5 and Figure 6 description fix

### DIFF
--- a/BufferStockTheory-NoAppendix.tex
+++ b/BufferStockTheory-NoAppendix.tex
@@ -1087,7 +1087,7 @@ consumption either exceeding $\bar{\cFunc}(\mRat)$ or lower than
 $\ushort{\cFunc}(\mRat)$.
 
 Figure~\ref{fig:mpclimits} confirms these limits visually.  The top
-plot shows the marginal propensity to consume, while the lower plot shows  the converged consumption function along with its upper and lower bounds.
+plot shows the marginal propensity to consume, while the lower plot shows the converged consumption function along with its upper and lower bounds.
 \renewcommand{\figFile}{mpclimits}
 \hypertarget{\figFile}{}
 \input{\FigDir/MPCLimits}

--- a/BufferStockTheory-NoAppendix.tex
+++ b/BufferStockTheory-NoAppendix.tex
@@ -1087,8 +1087,7 @@ consumption either exceeding $\bar{\cFunc}(\mRat)$ or lower than
 $\ushort{\cFunc}(\mRat)$.
 
 Figure~\ref{fig:mpclimits} confirms these limits visually.  The top
-plot shows the converged consumption function along with its upper and lower bounds,
-while the lower plot shows the marginal propensity to consume.
+plot shows the marginal propensity to consume, while the lower plot shows  the converged consumption function along with its upper and lower bounds.
 \renewcommand{\figFile}{mpclimits}
 \hypertarget{\figFile}{}
 \input{\FigDir/MPCLimits}

--- a/BufferStockTheory-NoAppendix.tex
+++ b/BufferStockTheory-NoAppendix.tex
@@ -1356,7 +1356,7 @@ The pseudo-steady-state still exists because it turns off realizations of the pe
 
 The surprising consequence is that, if the \GICRaw holds but the {\GICNrm}~fails, it is possible to construct an aggregate economy composed of consumers all of whom have target wealth of $\Trg{\mRat}=\infty$, but in which the aggregate economy still exhibits balanced growth with a finite ratio of aggregate wealth to income.  (For an example, see the software archive for the paper).
 
-This is a good introduction to a more explicit discssion of aggregation.
+This is a good introduction to a more explicit discussion of aggregation.
 
 
 \begin{comment}


### PR DESCRIPTION
This pull request already includes the typo fix from the other "Fixed Typo" pull request. 

The issue is that a sentence in the paper describing a figure above and a figure below its position seem to be mixed up. The description of the figure above the sentence seems to be the description for the figure below and vice versa.

To be specific,  when referring to a figure above and a figure below, the original sentence in the paper states:

"The top plot shows the converged consumption
function along with its upper and lower bounds, while the lower plot shows the marginal
propensity to consume." 

However, the top plot (the plot above the sentence) in both the pdf and html seems to plot the marginal propensity to consume while the plot below, the lower plot, seems to relate to the bounds of the consumption function. 